### PR TITLE
Fix desynced ranks, when a player overtakes another player‘s rank

### DIFF
--- a/bancho/common/database.py
+++ b/bancho/common/database.py
@@ -22,7 +22,9 @@ import bancho
 class Postgres:
     def __init__(self, username: str, password: str, host: str, port: int) -> None:
         self.engine = create_engine(
-            f'postgresql://{username}:{password}@{host}:{port}/{username}', 
+            f'postgresql://{username}:{password}@{host}:{port}/{username}',
+            max_overflow=30,
+            pool_size=15,
             echo=False
         )
 

--- a/bancho/common/database.py
+++ b/bancho/common/database.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm import sessionmaker, scoped_session, Session
 from sqlalchemy     import create_engine
 
 from typing import Optional, Generator, List
+from threading import Timer
 
 from .objects import (
     DBRelationship,
@@ -48,7 +49,10 @@ class Postgres:
             bancho.services.logger.critical(f'Transaction failed: "{e}". Performing rollback...')
             session.rollback()
         finally:
-            session.close()
+            Timer(
+                interval=10,
+                function=session.close
+            ).start()
 
     def user_by_name(self, name: str) -> Optional[DBUser]:
         return self.session.query(DBUser) \

--- a/bancho/handlers/b20120812.py
+++ b/bancho/handlers/b20120812.py
@@ -1,6 +1,7 @@
 
 from bancho.constants import PresenceFilter, ResponsePacket
 from bancho.streams import StreamOut, StreamIn
+from bancho.common.objects import DBStats
 from bancho.constants import (
     MatchScoringTypes,
     MatchTeamTypes,
@@ -34,6 +35,24 @@ class b20120812(b20121030):
             if self.player.filter == PresenceFilter.Friends:
                 if player.id not in self.player.friends:
                     return
+
+        cached_rank = bancho.services.cache.get_global_rank(
+            player.id,
+            player.current_stats.mode
+        )
+
+        if cached_rank != player.current_stats.rank:
+            # Update rank in database
+            instance = bancho.services.database.session
+            instance.query(DBStats) \
+                    .filter(DBStats.mode == player.current_stats.mode) \
+                    .filter(DBStats.user_id == player.id) \
+                    .update({
+                        "rank": cached_rank
+                    })
+            instance.commit()
+
+            player.current_stats.rank = cached_rank
 
         stream = StreamOut()
 


### PR DESCRIPTION
## Notable changes
- Fix desynced ranks from cache to database, after a player overtakes another player‘s rank

### Other changes
- Fix database pool size
- Add interval for closing database sessions