### PR TITLE
Refactor rank updates from cache & fix ghost spectators

### DIFF
--- a/bancho/handlers/b20120704.py
+++ b/bancho/handlers/b20120704.py
@@ -23,8 +23,6 @@ class b20120704(b20120725):
                 if player.id not in self.player.friends:
                     return
 
-        player.update_rank()
-
         stream = StreamOut()
         stream.s32(player.id)
 

--- a/bancho/handlers/b20120704.py
+++ b/bancho/handlers/b20120704.py
@@ -23,26 +23,9 @@ class b20120704(b20120725):
                 if player.id not in self.player.friends:
                     return
 
-        cached_rank = bancho.services.cache.get_global_rank(
-            player.id,
-            player.current_stats.mode
-        )
-
-        if cached_rank != player.current_stats.rank:
-            # Update rank in database
-            instance = bancho.services.database.session
-            instance.query(DBStats) \
-                    .filter(DBStats.mode == player.current_stats.mode) \
-                    .filter(DBStats.user_id == player.id) \
-                    .update({
-                        "rank": cached_rank
-                    })
-            instance.commit()
-
-            player.current_stats.rank = cached_rank
+        player.update_rank()
 
         stream = StreamOut()
-
         stream.s32(player.id)
 
         # Status

--- a/bancho/handlers/b20120812.py
+++ b/bancho/handlers/b20120812.py
@@ -36,8 +36,6 @@ class b20120812(b20121030):
                 if player.id not in self.player.friends:
                     return
 
-        player.update_rank()
-
         stream = StreamOut()
         stream.s32(player.id)
 
@@ -161,6 +159,7 @@ class b20120812(b20121030):
         bancho.services.cache.update_user(self.player)
 
         self.player.logger.debug(f'Changed status: {self.player.status}')
+        self.player.update_rank()
 
         # Enqueue to other players
         # (This needs to be done for older clients)

--- a/bancho/handlers/b20120812.py
+++ b/bancho/handlers/b20120812.py
@@ -36,26 +36,9 @@ class b20120812(b20121030):
                 if player.id not in self.player.friends:
                     return
 
-        cached_rank = bancho.services.cache.get_global_rank(
-            player.id,
-            player.current_stats.mode
-        )
-
-        if cached_rank != player.current_stats.rank:
-            # Update rank in database
-            instance = bancho.services.database.session
-            instance.query(DBStats) \
-                    .filter(DBStats.mode == player.current_stats.mode) \
-                    .filter(DBStats.user_id == player.id) \
-                    .update({
-                        "rank": cached_rank
-                    })
-            instance.commit()
-
-            player.current_stats.rank = cached_rank
+        player.update_rank()
 
         stream = StreamOut()
-
         stream.s32(player.id)
 
         # Status

--- a/bancho/handlers/b20121119.py
+++ b/bancho/handlers/b20121119.py
@@ -27,8 +27,6 @@ class b20121119(b20121223):
             else player.client.utc_offset
         )
 
-        player.update_rank()
-
         stream = StreamOut()
 
         stream.s32(player.id)

--- a/bancho/handlers/b20121119.py
+++ b/bancho/handlers/b20121119.py
@@ -27,6 +27,8 @@ class b20121119(b20121223):
             else player.client.utc_offset
         )
 
+        player.update_rank()
+
         stream = StreamOut()
 
         stream.s32(player.id)

--- a/bancho/handlers/b20121223.py
+++ b/bancho/handlers/b20121223.py
@@ -10,6 +10,7 @@ class b20121223(b20130329):
     def enqueue_players(self, players):
         def enqueue(players):
             for player in players:
+                player.update_rank()
                 self.enqueue_presence(player)
 
         Thread(
@@ -19,5 +20,6 @@ class b20121223(b20130329):
         ).start()
 
     def enqueue_player(self, player):
+        player.update_rank()
         self.enqueue_presence(player)
         self.enqueue_stats(player)

--- a/bancho/handlers/b20130606.py
+++ b/bancho/handlers/b20130606.py
@@ -822,6 +822,9 @@ class b20130606(BaseHandler):
                 self.enqueue_announcement(MANIA_NOT_SUPPORTED)
                 return
 
+        if (self.player.spectating) or (self.player in target.spectators):
+            self.handle_stop_spectating(None)
+
         self.player.spectating = target
 
         # Join their channel
@@ -840,7 +843,7 @@ class b20130606(BaseHandler):
         if target not in target.spectator_channel.users:
             target.handler.join_channel(f'#spec_{target.id}')
 
-    def handle_stop_spectating(self, stream: StreamIn):
+    def handle_stop_spectating(self, stream: Optional[StreamIn]):
         if self.player.restricted:
             return
 

--- a/bancho/handlers/b20130606.py
+++ b/bancho/handlers/b20130606.py
@@ -173,8 +173,6 @@ class b20130606(BaseHandler):
                 if player.id not in self.player.friends:
                     return
 
-        player.update_rank()
-
         stream = StreamOut()
         stream.s32(player.id)
 
@@ -531,6 +529,7 @@ class b20130606(BaseHandler):
         bancho.services.cache.update_user(self.player)
 
         self.player.logger.debug(f'Changed status: {self.player.status}')
+        self.player.update_rank()
 
         # Enqueue to other players
         # (This needs to be done for older clients)
@@ -646,6 +645,7 @@ class b20130606(BaseHandler):
         update_avaliable = stream.s32() == 1
 
     def handle_request_status(self, stream: StreamIn):
+        self.player.update_rank()
         self.enqueue_stats(self.player)
 
     def handle_join_lobby(self, stream: StreamIn):
@@ -726,6 +726,7 @@ class b20130606(BaseHandler):
         players = [bancho.services.players.by_id(id) for id in stream.intlist()]
 
         for player in players:
+            player.update_rank()
             self.enqueue_stats(player)
 
     def handle_presence_request(self, stream: StreamIn):

--- a/bancho/handlers/b20130606.py
+++ b/bancho/handlers/b20130606.py
@@ -145,8 +145,6 @@ class b20130606(BaseHandler):
             else player.client.utc_offset
         )
 
-        player.update_rank()
-
         stream = StreamOut()
 
         stream.s32(player.id)
@@ -737,6 +735,7 @@ class b20130606(BaseHandler):
         players = [bancho.services.players.by_id(id) for id in stream.intlist()]
 
         for player in players:
+            player.update_rank()
             self.enqueue_presence(player)
 
     def handle_presence_request_all(self, stream: StreamIn):

--- a/bancho/handlers/b20130606.py
+++ b/bancho/handlers/b20130606.py
@@ -145,6 +145,8 @@ class b20130606(BaseHandler):
             else player.client.utc_offset
         )
 
+        player.update_rank()
+
         stream = StreamOut()
 
         stream.s32(player.id)
@@ -173,26 +175,9 @@ class b20130606(BaseHandler):
                 if player.id not in self.player.friends:
                     return
 
-        cached_rank = bancho.services.cache.get_global_rank(
-            player.id,
-            player.current_stats.mode
-        )
-
-        if cached_rank != player.current_stats.rank:
-            # Update rank in database
-            instance = bancho.services.database.session
-            instance.query(DBStats) \
-                    .filter(DBStats.mode == player.current_stats.mode) \
-                    .filter(DBStats.user_id == player.id) \
-                    .update({
-                        "rank": cached_rank
-                    })
-            instance.commit()
-
-            player.current_stats.rank = cached_rank
+        player.update_rank()
 
         stream = StreamOut()
-
         stream.s32(player.id)
 
         # Status

--- a/bancho/objects/collections.py
+++ b/bancho/objects/collections.py
@@ -105,6 +105,8 @@ class Players(List[Player]):
         if player.restricted:
             return
 
+        player.update_rank()
+
         if force:
             player.handler.enqueue_stats(player, force=True)
 

--- a/bancho/objects/player.py
+++ b/bancho/objects/player.py
@@ -476,6 +476,25 @@ class Player(BanchoProtocol):
             force=True
         )
 
+    def update_rank(self):
+        cached_rank = bancho.services.cache.get_global_rank(
+            self.id,
+            self.current_stats.mode
+        )
+
+        if cached_rank != self.current_stats.rank:
+            # Update rank in database
+            instance = bancho.services.database.session
+            instance.query(DBStats) \
+                    .filter(DBStats.mode == self.current_stats.mode) \
+                    .filter(DBStats.user_id == self.id) \
+                    .update({
+                        "rank": cached_rank
+                    })
+            instance.commit()
+
+            self.current_stats.rank = cached_rank
+
     def create_stats(self):
         instance = bancho.services.database.session
 

--- a/bancho/objects/player.py
+++ b/bancho/objects/player.py
@@ -437,6 +437,7 @@ class Player(BanchoProtocol):
         self.handler.enqueue_privileges()
 
         # Presence and stats        
+        self.update_rank()
         self.handler.enqueue_presence(self)
         self.handler.enqueue_stats(self)
 


### PR DESCRIPTION
## Changes
1. Refactor rank updates from cache, to be *hopefully* more efficient
2. Fix duplicate/ghost spectators that appeared, when client didn‘t properly stopped spectating