### PR TITLE
Fix static datetime rows

### DIFF
--- a/bancho/common/objects.py
+++ b/bancho/common/objects.py
@@ -369,6 +369,7 @@ class DBUser(Base):
     preferred_mode   = Column('preferred_mode',   Integer, default=0)
     playstyle        = Column('playstyle',        Integer, default=0)
     userpage_content = Column('userpage_content', String, nullable=True)
+    userpage_banner  = Column('userpage_banner',  String, nullable=True)
     userpage_title   = Column('userpage_title',   String, nullable=True)
 
     replay_history = relationship('DBReplayHistory', back_populates='user')

--- a/bancho/common/objects.py
+++ b/bancho/common/objects.py
@@ -1,6 +1,7 @@
 
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from sqlalchemy.sql import func
 
 from datetime import datetime
 
@@ -86,7 +87,7 @@ class DBScore(Base):
     nKatu          = Column('nkatu', Integer)
     grade          = Column('grade', String, default='N')
     status         = Column('status', SmallInteger, default=-1)
-    submitted_at   = Column('submitted_at', DateTime, default=datetime.now())
+    submitted_at   = Column('submitted_at', DateTime, server_default=func.now())
 
     replay_md5     = Column('replay_md5', String, nullable=True)
     processes      = Column('processes',  String, nullable=True)
@@ -113,7 +114,7 @@ class DBFavourite(Base):
 
     user_id    = Column('user_id', Integer, ForeignKey('users.id'), primary_key=True)
     set_id     = Column('set_id', Integer, ForeignKey('beatmapsets.id'), primary_key=True)
-    created_at = Column('created_at', DateTime, default=datetime.now())
+    created_at = Column('created_at', DateTime, server_default=func.now())
 
     user       = relationship('DBUser', back_populates='favourites')
     beatmapset = relationship('DBBeatmapset', back_populates='favourites')
@@ -135,7 +136,7 @@ class DBScreenshot(Base):
 
     id         = Column('id', Integer, primary_key=True, autoincrement=True)
     user_id    = Column('user_id', ForeignKey('users.id'))
-    created_at = Column('created_at', DateTime, default=datetime.now())
+    created_at = Column('created_at', DateTime, server_default=func.now())
     hidden     = Column('hidden', Boolean, default=False)
 
     user = relationship('DBUser', back_populates='screenshots')
@@ -161,7 +162,7 @@ class DBComment(Base):
     target_id   = Column('target_id', Integer)
     target_type = Column('target_type', String)
     user_id     = Column('user_id', Integer, ForeignKey('users.id'))
-    time        = Column('time', DateTime, default=datetime.now())
+    time        = Column('time', DateTime, server_default=func.now())
     comment     = Column('comment', String)
     format      = Column('format', String, nullable=True)
     mode        = Column('mode', SmallInteger, default=0)
@@ -173,7 +174,7 @@ class DBLog(Base):
     level   = Column('level', String)
     type    = Column('type', String)
     message = Column('message', String)
-    time    = Column('time', DateTime, default=datetime.now())
+    time    = Column('time', DateTime, server_default=func.now())
 
     def __init__(self, message: str, level: str, type: str) -> None:
         self.message = message
@@ -195,7 +196,7 @@ class DBMessage(Base):
     sender  = Column('sender', String, ForeignKey('users.name'))
     target  = Column('target', String) # Either channel or username
     message = Column('message', String)
-    time    = Column('time', DateTime, default=datetime.now())
+    time    = Column('time', DateTime, server_default=func.now())
 
     def __init__(self, sender: str, target: str, message: str) -> None:
         self.message = message
@@ -215,9 +216,9 @@ class DBBeatmapset(Base):
     has_video   = Column('has_video', Boolean, default=False)
     server      = Column('server', SmallInteger, default=0)
     available   = Column('available', Boolean, default=True)
-    created_at  = Column('submission_date', DateTime, default=datetime.now())
+    created_at  = Column('submission_date', DateTime, server_default=func.now())
     approved_at = Column('approved_date', DateTime, nullable=True)
-    last_update = Column('last_updated', DateTime, default=datetime.now())
+    last_update = Column('last_updated', DateTime, server_default=func.now())
     added_at    = Column('added_at', DateTime, nullable=True) # only if server is 0 (osu!)
 
     favourites = relationship('DBFavourite', back_populates='beatmapset')
@@ -235,8 +236,8 @@ class DBBeatmap(Base):
     status       = Column('status', SmallInteger, default=2)
     version      = Column('version', String)
     filename     = Column('filename', String)
-    created_at   = Column('submission_date', DateTime, default=datetime.now())
-    last_update  = Column('last_updated', DateTime, default=datetime.now())
+    created_at   = Column('submission_date', DateTime, server_default=func.now())
+    last_update  = Column('last_updated', DateTime, server_default=func.now())
     playcount    = Column('playcount', BigInteger, default=0)
     passcount    = Column('passcount', BigInteger, default=0)
     total_length = Column('total_length', Integer)
@@ -266,7 +267,7 @@ class DBBadge(Base):
 
     id                = Column('id', Integer, primary_key=True, autoincrement=True)
     user_id           = Column('user_id', Integer, ForeignKey('users.id'))
-    created           = Column('created', DateTime, default=datetime.now())
+    created           = Column('created', DateTime, server_default=func.now())
     badge_icon        = Column('badge_icon', String)
     badge_url         = Column('badge_url', String, nullable=True)
     badge_description = Column('badge_description', String, nullable=True)
@@ -278,7 +279,7 @@ class DBActivity(Base):
 
     id             = Column('id', Integer, primary_key=True, autoincrement=True)
     user_id        = Column('user_id', Integer, ForeignKey('users.id'))
-    time           = Column('time', DateTime, default=datetime.now())
+    time           = Column('time', DateTime, server_default=func.now())
     mode           = Column('mode', SmallInteger)
     activity_text  = Column('activity_text', String)
     activity_args  = Column('activity_args', String, nullable=True)
@@ -291,7 +292,7 @@ class DBName(Base):
 
     id         = Column('id', Integer, primary_key=True, autoincrement=True)
     user_id    = Column('user_id', Integer, ForeignKey('users.id'))
-    changed_at = Column('changed_at', DateTime, default=datetime.now())
+    changed_at = Column('changed_at', DateTime, server_default=func.now())
     name       = Column('name', String)
 
     user = relationship('DBUser', back_populates='names')
@@ -300,7 +301,7 @@ class DBRankHistory(Base):
     __tablename__ = "profile_rank_history"
 
     user_id      = Column('user_id', Integer, ForeignKey('users.id'), primary_key=True)
-    time         = Column('time', DateTime, default=datetime.now(), primary_key=True)
+    time         = Column('time', DateTime, server_default=func.now(), primary_key=True)
     mode         = Column('mode', SmallInteger)
     rscore       = Column('rscore', BigInteger)
     pp           = Column('pp', Integer)
@@ -362,8 +363,8 @@ class DBUser(Base):
     country          = Column('country',          String)
     silence_end      = Column('silence_end',      DateTime, nullable=True)
     supporter_end    = Column('supporter_end',    DateTime, nullable=True)
-    created_at       = Column('created_at',       DateTime, default=datetime.now())
-    latest_activity  = Column('latest_activity',  DateTime, default=datetime.now())
+    created_at       = Column('created_at',       DateTime, server_default=func.now())
+    latest_activity  = Column('latest_activity',  DateTime, server_default=func.now())
     restricted       = Column('restricted',       Boolean, default=False)
     activated        = Column('activated',        Boolean, default=False)
     preferred_mode   = Column('preferred_mode',   Integer, default=0)


### PR DESCRIPTION
## Critical fix
This was very painful to discover. Basically, every table in sqlalchemy with ...
```python
default=datetime.now()
```
... as an attribute did not actually get the latest datetime, but instead the datetime when this table was initialized.
I noticed this because the 'profile_rank_history' table was spitting out errors, because the "time" attribute is a primary key and the "time" value is always the same.

This could go on r/facepalm tbh...